### PR TITLE
Fix event listeners for menu/copy/tweet

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -55,67 +55,53 @@ $search.onkeyup = function () {
   }
 };
 
-[document.querySelector('.search-form')]
-  .forEach(f => f && f.addEventListener('submit', e => {
-    if ($search.value.length <= 2 && $searchType.value != 5) {
-      alert('Please enter at least 3 characters');
-      e.preventDefault();
-      return false;
-    }
-  }));
+function attachEventListeners () {
+  // Search form validator
+  [document.querySelector('.search-form')]
+    .forEach(f => f && f.addEventListener('submit', e => {
+      if ($search.value.length <= 2 && $searchType.value != 5) {
+        alert('Please enter at least 3 characters');
+        e.preventDefault();
+        return false;
+      }
+    }));
 
-// Shabad controller toggles
-[...document.querySelectorAll('.shabad-controller-toggle')]
-  .forEach(e => e && e.addEventListener('click', shabadToggle));
+  // Shabad controller toggles
+  [...document.querySelectorAll('.shabad-controller-toggle')]
+    .forEach(e => e && e.addEventListener('click', shabadToggle));
 
-// Shabad display option toggles
-[...document.querySelectorAll('.display-option-toggle')]
-  .forEach(e => e && e.addEventListener('click', displayOptionToggle));
+  // Shabad display option toggles
+  [...document.querySelectorAll('.display-option-toggle')]
+    .forEach(e => e && e.addEventListener('click', displayOptionToggle));
 
-[document.getElementById('open-mobile-menu')]
-  .forEach(e => e && addEventListener('click', () => document.body.classList.toggle('menu-open')));
+  // Mobile hamburger menu
+  [document.getElementById('open-mobile-menu')]
+    .forEach(e => e && e.addEventListener('click', () => document.body.classList.toggle('menu-open')));
 
-[document.querySelector('.top-bar-right .close a')]
-  .forEach(e => e && addEventListener('click', () => document.body.classList.remove('menu-open')));
+  // Close menu
+  [document.querySelector('.top-bar-right .close a')]
+    .forEach(e => e && e.addEventListener('click', () => document.body.classList.remove('menu-open')));
 
-[document.getElementById('open_share_menu')]
-  .forEach(e => e && addEventListener('click', () => document.body.classList.toggle('share-open')));
+  // Share menu
+  [document.getElementById('open_share_menu')]
+    .forEach(e => e && e.addEventListener('click', () => document.body.classList.toggle('share-open')));
 
-[...document.querySelectorAll('#search-options select')]
-  .forEach(e => e && e.addEventListener('change', function () {
-    const update = this.dataset.update;
-    document.getElementById(update).value = this.value;
-    if (this.getAttribute('id') === 'search-source') {
-      document.getElementById('top-bar-search-form').submit();
-    }
-  }));
+  [...document.querySelectorAll('#search-options select')]
+    .forEach(e => e && e.addEventListener('change', function () {
+      const update = this.dataset.update;
+      document.getElementById(update).value = this.value;
+      if (this.getAttribute('id') === 'search-source') {
+        document.getElementById('top-bar-search-form').submit();
+      }
+    }));
 
-[document.querySelector('.gurmukhi-keyboard-toggle')]
-  .forEach(e => e && e.addEventListener('click', () => document.querySelector('.gurmukhi-keyboard').classList.toggle('active')));
+  [document.querySelector('.gurmukhi-keyboard-toggle')]
+    .forEach(e => e && e.addEventListener('click', () => document.querySelector('.gurmukhi-keyboard').classList.toggle('active')));
+}
 
-$('#shabad').on('click', '.share .copy', function() {
-  const el = $(this).parents('.line').children('textarea');
-  el.show().select();
-  document.execCommand('copy');
-  el.blur().hide();
+document.addEventListener('DOMContentLoaded', () => {
+  attachEventListeners();
 });
-
-$('#shabad').on('click', '.share .twitter', function () {
-  let tweet = $(this).parents('.line').children('textarea').val();
-  const shortURL = `\n${shortenURL()}`;
-  if (tweet.length + shortURL.length > 134) {
-    tweet = `${tweet.substring(0, 132 - shortURL.length)}..`;
-  }
-  tweet += shortURL;
-  tweet += ' #sttm';
-  window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(tweet)}`, '_blank');
-});
-
-/*$("#shabad").on("click", ".share .facebook", function() {
-  let post = $(this).parents(".line").children("textarea").val();
-  post += " #sttm";
-  window.open("https://www.facebook.com/sharer/sharer.php?u=" + encodeURIComponent("http://www.sikhitothemax.org") + "&t=" + encodeURIComponent(post), "_blank");
-});*/
 
 function updateSearchLang(e) {
   const searchType = parseInt(e.currentTarget.value);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -55,6 +55,8 @@ $search.onkeyup = function () {
   }
 };
 
+// Note: Don't add listeners to JS rendered DOM Nodes. Use h() to bind eventListeners to them.
+
 function attachEventListeners () {
   // Search form validator
   [document.querySelector('.search-form')]
@@ -65,14 +67,6 @@ function attachEventListeners () {
         return false;
       }
     }));
-
-  // Shabad controller toggles
-  [...document.querySelectorAll('.shabad-controller-toggle')]
-    .forEach(e => e && e.addEventListener('click', shabadToggle));
-
-  // Shabad display option toggles
-  [...document.querySelectorAll('.display-option-toggle')]
-    .forEach(e => e && e.addEventListener('click', displayOptionToggle));
 
   // Mobile hamburger menu
   [document.getElementById('open-mobile-menu')]

--- a/src/js/renderShabad.js
+++ b/src/js/renderShabad.js
@@ -2,9 +2,9 @@ function renderShabad(gurbani, nav) {
   document.body.classList.remove("loading");
 
   let footnav = null;
-  if(typeof nav != "undefined") {
-    let link        = navLink(nav);
-    let pagination  = [];
+  if (typeof nav != "undefined") {
+    let link = navLink(nav);
+    let pagination = [];
     if (typeof nav.previous != "undefined") {
       pagination.push(<div class="shabad-nav left"><a href={link + nav.previous}><i class="fa fa-chevron-left" aria-hidden="true"></i><span>Previous</span></a></div>);
     }
@@ -15,7 +15,7 @@ function renderShabad(gurbani, nav) {
     footnav = <div class="pagination">{pagination}</div>;
   }
 
-  $shabad.appendChild(<div class="shabad-container">{[ Baani(gurbani), footnav, ]}</div>);
+  $shabad.appendChild(<div class="shabad-container">{[Baani(gurbani), footnav,]}</div>);
 
   prefs
     .displayOptions
@@ -91,6 +91,27 @@ function metaData(data, nav) {
 }
 
 function Baani(gurbani) {
+  const onCopyClick = ({ currentTarget }) => {
+    const textarea = currentTarget.parentNode.parentNode.querySelector('textarea');
+    textarea.style.display = 'block';
+    textarea.focus();
+    textarea.select();
+    document.execCommand('copy');
+    textarea.blur();
+    textarea.style.display = 'none';
+  };
+
+  const onTweetClick = ({ currentTarget}) => {
+    let tweet = currentTarget.parentNode.parentNode.querySelector('textarea').value;
+    const shortURL = `\n${shortenURL()}`;
+    if (tweet.length + shortURL.length > 134) {
+      tweet = `${tweet.substring(0, 132 - shortURL.length)}..`;
+    }
+    tweet += shortURL;
+    tweet += ' #sttm';
+    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(tweet)}`, '_blank');
+  };
+
   const BaaniLine = ({ gurmukhi, unicode }) => (
     <div class="gurmukhi gurbani-display gurbani-font" >
       <div class="gurlipi">{prepareLarivaar(gurmukhi)}</div>
@@ -125,8 +146,8 @@ function Baani(gurbani) {
               {EnglishTranslation({ translation: shabad.translation.english.ssk })}
               {SpanishTranslation({ translation: shabad.translation.spanish })}
               <div class="share">
-                <a class="copy"><i class="fa fa-fw fa-clipboard" /></a>
-                <a class="twitter"><i class="fa fa-fw fa-twitter" /></a>
+                <a class="copy" click={onCopyClick}><i class="fa fa-fw fa-clipboard" /></a>
+                <a class="twitter" click={onTweetClick}><i class="fa fa-fw fa-twitter" /></a>
                 {/*<a class="facebook"><i class="fa fa-fw fa-facebook" /></a>*/}
               </div>
               <textarea>{`${shabad.gurbani.unicode}\n${shabad.translation.english.ssk}`}</textarea>

--- a/src/js/renderShabad.js
+++ b/src/js/renderShabad.js
@@ -104,8 +104,8 @@ function Baani(gurbani) {
   const onTweetClick = ({ currentTarget}) => {
     let tweet = currentTarget.parentNode.parentNode.querySelector('textarea').value;
     const shortURL = `\n${shortenURL()}`;
-    if (tweet.length + shortURL.length > 134) {
-      tweet = `${tweet.substring(0, 132 - shortURL.length)}..`;
+    if (tweet.length + shortURL.length > 274) {
+      tweet = `${tweet.substring(0, 272 - shortURL.length)}…`;
     }
     tweet += shortURL;
     tweet += ' #sttm';


### PR DESCRIPTION
* Moved copy/tweet event listeners to renderShabad, where they should
reside.
* Added eventListeners to a DOMReady callback.
* Fixed a typo in code where event listeners weren't attached to element
but window object itself.