### PR TITLE
Hide metadata borders when empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,15 +40,19 @@
                        name="q"
                        id="search"
                        class="gurbani-font"
-                       placeholder="Koj"
+                       placeholder="jmTAq"
                        autocomplete="off"
                        autocapitalize="none"
                        autocorrect="off"
                        spellcheck="false"
-                       pattern=".{3,}"
+                       pattern=".{2,}"
                        required
-                       title="Enter 3 characters minimum."
+                       title="Enter 2 characters minimum."
                      />
+
+                    <button type="button" class="clear-search-toggle">
+                      <i class="fa fa-times"></i>
+                    </button>
 
                     <button class="gurmukhi-keyboard-toggle" type="button">
                       <i class="fa fa-keyboard-o"></i>
@@ -84,21 +88,27 @@
 
         <div class="row">
           <ul class="menu footer-menu">
+            <li><a href="/help">Help</a></li>
             <li><a href="/about">About Us</a></li>
-            <li><a href="https://goo.gl/plk23h" target="_blank">Feedback</a></li>
+            <li><a href="https://form.jotform.com/80266126732151" target="_blank">Feedback</a></li>
             <li><a href="/terms-of-service">Terms of Service</a></li>
             <li><a href="https://khalisfoundation.org/portfolio/sikhitothemax-everywhere/" target="_blank">Desktop App</a></li>
           </ul>
         </div>
       </footer>
       <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-ga('create', 'UA-47386101-5', 'auto');
-ga('send', 'pageview');
+        var ga;
+        if (document.location.hostname === 'www.sikhitothemax.com') {
+          /* GA script here */
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        } else {
+          ga = (...args) => console.log('ga:', args);
+        }
+        ga('create', 'UA-47386101-5', 'auto');
+        ga('send', 'pageview');
       </script>
 
       <!-- Vendor Scripts -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSONStream": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -4261,6 +4251,15 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4270,15 +4269,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5515,6 +5505,16 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -7819,6 +7819,15 @@
         "xtend": "4.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7839,15 +7848,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0",
         "function-bind": "1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,23 @@
 {
   "name": "SikhiToTheMax-Web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "accepts": {
@@ -116,7 +126,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -155,7 +165,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -165,7 +175,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "are-we-there-yet": {
@@ -199,7 +209,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "array-differ": {
@@ -273,7 +283,7 @@
     "asn1.js": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "integrity": "sha1-gRfvT37YfNj4kES1v/l6wkOhbJo=",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -1072,19 +1082,19 @@
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.8.5.tgz",
-      "integrity": "sha512-Ux3ligf+ukzWaCbBYOstDuFBhRgMiJHlpJBKV4P47qtzVkd0lg1ddPj9fqIJqAM0n+CvxipyrZrnNnw3CdtQCg==",
+      "integrity": "sha1-4GrjBc9I2BmCLpOnDXkmnwTYnuw=",
       "dev": true
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.8.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.8.6.tgz",
-      "integrity": "sha512-o5Jioq553HtEAUN5uty7ELJMenXIxHI3PIs1yLqYWYQwP6mg6IPVAJ+U7i4zr9XGF/kb2RGsdehglGTV+vngqA==",
+      "integrity": "sha1-bSHvpe5JgfcWV/rnFvlZS7JiKu8=",
       "dev": true
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.8.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.3.tgz",
-      "integrity": "sha512-bPbUhkeN2Nc0KH0/A19GwQGj8w+CvdJzyu8t59VoEDgsNMQ9Bopzi5DrVkrSsVjbYUaZpzq/DYLrH+wD5K2Tig==",
+      "integrity": "sha1-WQbtd203GCUFGavxus5EsLYT3fk=",
       "dev": true
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1100,7 +1110,7 @@
     "babel-plugin-transform-property-literals": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.5.tgz",
-      "integrity": "sha512-MmiQsQ5AcIaRZMJD0zY5C4H3xuHm06/nWgtOsz7AXV44VEIXIlPiJ39IFYJ4Qx67/fEm8zJAedzR8t+B7d10Bg==",
+      "integrity": "sha1-Z+1ZMLNIBUQ0Usi5aQx+vh4gbEA=",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -1135,13 +1145,13 @@
     "babel-plugin-transform-remove-console": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.5.tgz",
-      "integrity": "sha512-uuCKvtweCyIvvC8fi92EcWRtO2Kt5KMNMRK6BhpDXdeb3sxvGM7453RSmgeu4DlKns3OlvY9Ep5Q9m5a7RQAgg==",
+      "integrity": "sha1-/enS09clUwsPrdjTEHhAJBA4aBA=",
       "dev": true
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.8.5.tgz",
-      "integrity": "sha512-InDQDdHPOLJKM+G6oXrEesf+P29QFBmcTXID+TAvZziVz+38xe2VO/Bn3FcRcRtnOOycbgsJkUNp9jIK+ist6g==",
+      "integrity": "sha1-gJWE1BK/kY8HH99B4f2xXqic3NU=",
       "dev": true
     },
     "babel-plugin-transform-remove-undefined": {
@@ -1153,7 +1163,7 @@
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.8.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.5.tgz",
-      "integrity": "sha512-B3HlBZb+Uq86nRj5yNPO6pJ3noEdqHvzYkEYoUWtrsWTv48ZIRatYlumoOiif/v8llF13YjYjx9zhyznDx+N9g==",
+      "integrity": "sha1-qDh4a69AzDOpO5WuCeBVkSJ+Q78=",
       "dev": true
     },
     "babel-plugin-transform-strict-mode": {
@@ -1169,7 +1179,7 @@
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.8.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.3.tgz",
-      "integrity": "sha512-goYwp8dMrzHD6x9GjZ2M85Mk2vxf1h85CnUgAjfftUnlJvzF4uj5MrbReHBTbjQ96C8CuRzvhYZ3tv8H3Sc1ZA==",
+      "integrity": "sha1-/FJwf27h3ccbuRsNMU++/e75vrQ=",
       "dev": true
     },
     "babel-polyfill": {
@@ -1351,7 +1361,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
       "dev": true
     },
     "balanced-match": {
@@ -1363,7 +1373,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -1379,7 +1389,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
       "dev": true
     },
     "binary-extensions": {
@@ -1406,7 +1416,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "body-parser": {
@@ -1554,7 +1564,7 @@
     "browserify-aes": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
-      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+      "integrity": "sha1-OLerVe24Bv8tzaGn8WIHc6R3xJ8=",
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
@@ -1615,7 +1625,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "1.0.6"
@@ -1773,7 +1783,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -1783,7 +1793,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clean-css": {
@@ -2009,7 +2019,7 @@
     "configstore": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "integrity": "sha1-CU7mYquD+tmRdnjeEU+q6o/NypA=",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -2055,7 +2065,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -2088,7 +2098,7 @@
     "cosmiconfig": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
@@ -2166,7 +2176,7 @@
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -2187,7 +2197,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
@@ -2339,7 +2349,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2574,7 +2584,7 @@
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
@@ -2695,7 +2705,7 @@
     "errno": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+      "integrity": "sha1-w4bOimKD8U/AlWO3FWCQjJv1MCY=",
       "dev": true,
       "requires": {
         "prr": "1.0.1"
@@ -2899,7 +2909,7 @@
     "eslint-config-airbnb-base": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
-      "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
+      "integrity": "sha1-hwOxGr48iKx+wrdFt/31LgCuaAo=",
       "dev": true,
       "requires": {
         "eslint-restricted-globals": "0.1.1"
@@ -2918,7 +2928,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -2974,7 +2984,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -3047,7 +3057,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "1.3.4",
@@ -3083,7 +3093,7 @@
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -4251,15 +4261,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4269,6 +4270,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4423,7 +4433,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "gather-stream": {
@@ -4510,7 +4520,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -4543,7 +4553,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -4656,7 +4666,7 @@
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -4711,7 +4721,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "html-minifier": {
@@ -4879,7 +4889,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
     },
     "ieee754": {
       "version": "1.1.8",
@@ -5302,7 +5312,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -5422,7 +5432,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0=",
       "dev": true
     },
     "json-schema": {
@@ -5506,16 +5516,6 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5553,7 +5553,7 @@
     "known-css-properties": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.2.0.tgz",
-      "integrity": "sha512-UTCzU28rRI9wkb8qSGoZa9pgWvxr4LjP2MEhi9XHb/1XMOJy0uTnIxaxzj8My/PORG+kQG6VzAcGvRw66eIOfA==",
+      "integrity": "sha1-iZyUvjaOVbQtfbjVvn1zpKSkFFQ=",
       "dev": true
     },
     "latest-version": {
@@ -6061,7 +6061,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -6071,7 +6071,7 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
     },
     "mime-db": {
       "version": "1.30.0",
@@ -6107,7 +6107,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -6176,7 +6176,7 @@
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
@@ -6223,7 +6223,7 @@
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+      "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
       "dev": true,
       "requires": {
         "assert": "1.4.1",
@@ -6254,7 +6254,7 @@
     "node-sass": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
+      "integrity": "sha1-k2Z3i6FGnrAUOKnoWS9CYry2eU4=",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -6319,7 +6319,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -6430,7 +6430,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -6631,7 +6631,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
       "dev": true
     },
     "param-case": {
@@ -6753,7 +6753,7 @@
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "integrity": "sha1-o14TxkeZsGzhUyD0WcIw5o5zut4=",
       "dev": true,
       "requires": {
         "create-hash": "1.1.3",
@@ -7010,7 +7010,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "querystring": {
       "version": "0.2.0",
@@ -7027,7 +7027,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -7077,7 +7077,7 @@
     "randomfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "integrity": "sha1-uWt99YfwHdkXJsQY8wVTsUGOPWI=",
       "dev": true,
       "requires": {
         "randombytes": "2.0.5",
@@ -7164,7 +7164,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -7221,7 +7221,7 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "integrity": "sha1-DDNtOYBVPXVcObWGrjsgqknIK38=",
       "dev": true
     },
     "regenerator-runtime": {
@@ -7233,7 +7233,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -7244,7 +7244,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
@@ -7458,7 +7458,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -7492,7 +7492,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -7545,7 +7545,7 @@
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "integrity": "sha1-pw4coh0TgsEdDZ9iMd6ygQgNerM=",
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.1",
@@ -7565,7 +7565,7 @@
     "serve-static": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "integrity": "sha1-TFfVNASnYdjy58HooYpH2/J4pxk=",
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -7594,7 +7594,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
     },
     "sha.js": {
       "version": "2.4.9",
@@ -7680,7 +7680,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU=",
       "dev": true
     },
     "source-map": {
@@ -7692,7 +7692,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
@@ -7722,7 +7722,7 @@
     "specificity": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
-      "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
+      "integrity": "sha1-meZRHs7vD42bV5JJN6rCyxPRPEI=",
       "dev": true
     },
     "split": {
@@ -7819,15 +7819,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7848,6 +7839,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.9.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -8021,7 +8021,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -8078,7 +8078,7 @@
         "slice-ansi": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0"
@@ -8087,7 +8087,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -8115,7 +8115,7 @@
         "table": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
           "dev": true,
           "requires": {
             "ajv": "5.2.3",
@@ -8219,7 +8219,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -8347,7 +8347,7 @@
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
       "dev": true,
       "requires": {
         "nopt": "1.0.10"
@@ -8733,7 +8733,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -8744,7 +8744,7 @@
     "webpack": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "integrity": "sha1-UpG4dQeM8qv0K90jr+P4+WwX1yU=",
       "dev": true,
       "requires": {
         "acorn": "5.1.2",
@@ -8798,7 +8798,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -8839,7 +8839,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -8850,7 +8850,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -8916,7 +8916,7 @@
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+      "integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
       "dev": true,
       "requires": {
         "source-list-map": "2.0.0",
@@ -8926,7 +8926,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -8934,7 +8934,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -8949,7 +8949,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -9015,7 +9015,7 @@
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SikhiToTheMax-Web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Sevadaars are currently working hard to build a newer version of SikhiToTheMax website using modern web technologies.",
   "main": "index.js",
   "scripts": {

--- a/src/js/components/SearchForm.js
+++ b/src/js/components/SearchForm.js
@@ -8,14 +8,14 @@ export default ({ }) => {
       id="search"
       class="gurbani-font"
       type="search"
-      placeholder="Koj"
+      placeholder="jmTAq"
       autocapitalize="none"
       autocomplete="off"
       autocorrect="off"
       spellcheck="false"
       required='required'
-      title='Enter 3 characters minimum.'
-      pattern='.{3,}'
+      title='Enter 2 characters minimum.'
+      pattern='.{2,}'
     />
   );
 
@@ -45,7 +45,15 @@ export default ({ }) => {
 
           {$search}
 
-          <button 
+          <button
+            type="button"
+            class="clear-search-toggle"
+            click={() => $search.value=''}
+          >
+            <i class="fa fa-times" />
+          </button>
+
+          <button
             type="button"
             class="gurmukhi-keyboard-toggle"
             click={() => gurmukhiKeyboard.classList.toggle('active')}

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -13,6 +13,13 @@ var content = {
     <span style="font-weight: 500;">Acknowledgements:</span> Bhai Tarsem Singh UK, SHARE UK, Khalis Foundation, Khalsa Foundation UK, Dr. Sant Singh Khalsa, Dr. Kulbir Singh Thind
     `,
   },
+  '/help': {
+    title: "Help Section",
+    content: `
+          <b>Watch this tutorial to get started:</b>
+          <div class="center"><iframe width="560" height="315" src="https://www.youtube.com/embed/ZDX8nPkDBSc" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></div>
+    `,
+  },
   '/terms-of-service': {
     title: 'Terms of Service',
     content: `

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,17 +1,19 @@
 const $search = document.getElementById('search');
 const $searchType = document.getElementById('search-type');
-let   $controls = document.getElementById('controls-wrapper');
-let   $shabad = document.getElementById('shabad');
-let   $meta = document.getElementById('metadata');
+let $controls = document.getElementById('controls-wrapper');
+let $shabad = document.getElementById('shabad');
+let $meta = document.getElementById('metadata');
 const prefs = {};
 const defaultPrefs = {
   displayOptions: ['translation-english', 'transliteration-english'],
   shabadToggles: [],
+  sliders: { 'font-size-slider': '16' },
 };
+let placeholderAni;
 
 function shortenURL(url = window.location.href) {
   const path = window.location.pathname;
-  const shortdomain = 'sttm.ws';
+  const shortdomain = 'sttm.co';
   const URL = `http://${shortdomain}`;
 
   switch (path) {
@@ -32,7 +34,7 @@ const getPrefs = () => Object
 const setPref = (key, val) => localStorage.setItem(key, JSON.stringify(val));
 
 function checkboxPref(e, key, option) {
-  if (e.target.classList.contains('active')) {
+  if (e.currentTarget.classList.contains('active')) {
     if (prefs[key].indexOf(option) < 0) {
       prefs[key].push(option);
     }
@@ -43,31 +45,13 @@ function checkboxPref(e, key, option) {
   setPref(key, prefs[key]);
 }
 
-getPrefs();
-
-if ($searchType) $searchType.addEventListener('change', updateSearchLang);
-
-if ($searchType) $searchType.addEventListener('change', updateSearchAction);
-
-$search.onkeyup = function () {
-  if ($searchType.value == 5 && this.value != this.value.replace(/[^0-9]/g, '')) {
-    this.value = this.value.replace(/[^0-9]/g, '');
-  }
-};
+function forceSearchNumeric() {
+  $search.value = $search.value.replace(/\D/g, '');
+}
 
 // Note: Don't add listeners to JS rendered DOM Nodes. Use h() to bind eventListeners to them.
 
 function attachEventListeners () {
-  // Search form validator
-  [document.querySelector('.search-form')]
-    .forEach(f => f && f.addEventListener('submit', e => {
-      if ($search.value.length <= 2 && $searchType.value != 5) {
-        alert('Please enter at least 3 characters');
-        e.preventDefault();
-        return false;
-      }
-    }));
-
   // Mobile hamburger menu
   [document.getElementById('open-mobile-menu')]
     .forEach(e => e && e.addEventListener('click', () => document.body.classList.toggle('menu-open')));
@@ -90,48 +74,87 @@ function attachEventListeners () {
     }));
 
   [document.querySelector('.gurmukhi-keyboard-toggle')]
-    .forEach(e => e && e.addEventListener('click', () => document.querySelector('.gurmukhi-keyboard').classList.toggle('active')));
+    .forEach(e => e && e.addEventListener('click', () => [e, document.querySelector('.gurmukhi-keyboard')].forEach((f) => { f.classList.toggle('active'); })));
+
+  [document.querySelector('.clear-search-toggle')]
+    .forEach(e => e && e.addEventListener('click', () => $search.value=''));
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   attachEventListeners();
 });
 
-function updateSearchLang(e) {
-  const searchType = parseInt(e.currentTarget.value);
-  const $form = e.currentTarget.form || document.querySelector('.search-form');
-  const $search = $form.q;
+function animatePlaceholder(e, content) {
+  // todo - have a single $search var that points to the actual input element
+  const $form = e.target.form || document.querySelector('.search-form');
+  const $searchField = $form.q;
+  // animate over 2 seconds
+  const aniTime = 2000 / content.length;
 
-  switch (searchType) {
-    case 3:
-    case 4:
-    case 5:
-      $search.classList.remove('gurbani-font');
-      $search.placeholder = searchType === 5 ? 'Ang Number' : 'Khoj';
-      break;
-    default:
-      $search.classList.add('gurbani-font');
-      $search.placeholder = 'Koj';
-      break;
+  const curPlaceholderLength = $searchField.placeholder.length;
+  const newPlaceholder = content.substr(0, curPlaceholderLength + 1);
+  $searchField.placeholder = newPlaceholder;
+  if (newPlaceholder !== content) {
+    placeholderAni = setTimeout((el) => {
+      animatePlaceholder(el, content);
+    }, aniTime, e);
   }
+}
+
+function updateSearchContent(e, content = 'Koj', useEnglish = false) {
+  const $form = e.target.form || document.querySelector('.search-form');
+  const $searchField = $form.q;
+
+  if (useEnglish) {
+    $searchField.classList.remove('gurbani-font');
+  } else {
+    $searchField.classList.add('gurbani-font');
+  }
+
+  clearTimeout(placeholderAni);
+  $searchField.placeholder = '';
+  animatePlaceholder(e, content);
+}
+
+function updateSearchLang(e) {
+  const searchType = parseInt(e.target.value, 10);
+
+  const options = {
+    0: ['jmTAq'], // first letters
+    1: ['mqjbe'], // first letter anywhere
+    2: ['jo mwgih Twkur Apuny qy'], // gurmukhi
+    3: ['He has extended His power', true], // translation
+    4: ['jo mange thakur apne te soi', true], // romanized
+    5: ['123', true], //ang
+  };
+
+  updateSearchContent(e, options[searchType][0], options[searchType][1]);
+
   $searchType.value = searchType;
 }
 
 function updateSearchAction(e) {
-  const searchType = parseInt(e.currentTarget.value);
-  const $form = e.currentTarget.form || document.querySelector('.search-form');
+  const searchType = parseInt(e.target.value);
+  const $form = e.target.form || document.querySelector('.search-form');
   const $search = $form.q;
 
   switch (searchType) {
+    case 4:
+      $search.setAttribute('pattern', '(\\w+\\W+){3,}\\w+\\W*');
+      $search.setAttribute('title', 'Enter 4 words minimum.');
+      $form.setAttribute('action', '/search');
+      $search.setAttribute('name', 'q');
+      break;
     case 5:
+      forceSearchNumeric();
       $form.setAttribute('action', '/ang');
       $search.setAttribute('name', 'ang');
       $search.removeAttribute('pattern');
       $search.removeAttribute('title', '');
       break;
     default:
-      $search.setAttribute('pattern', '.{3,}');
-      $search.setAttribute('title', 'Enter 3 characters minimum.');
+      $search.setAttribute('pattern', '.{2,}');
+      $search.setAttribute('title', 'Enter 2 characters minimum.');
       $form.setAttribute('action', '/search');
       $search.setAttribute('name', 'q');
       break;
@@ -139,22 +162,76 @@ function updateSearchAction(e) {
   $searchType.value = searchType;
 }
 
+function displayOptionSlider(e) {
+  const option = e.id;
+  let prefVal = prefs.sliders;
+
+  switch (option) {
+    case 'font-size-slider': {
+      prefVal[option] = e.value;
+      const fontSize = `${(e.value / 10).toString()}em`;
+      [...document.querySelectorAll('.gurbani-display')].forEach((line) => {
+        line.style.fontSize = fontSize;
+      });
+      break;
+    }
+    default:
+      break;
+  }
+  prefs.sliders = prefVal;
+  setPref('sliders', prefVal);
+}
+
+function addSpaceForPadChed(status) {
+  // add padched
+  if (status) {
+    const padChedDiv = '<span class="padChedDiv"> </span>';
+
+    [...document.querySelectorAll('.akhar')]
+      .forEach((element) => {
+        const str = element.innerHTML;
+        const text = str + padChedDiv;
+        element.innerHTML = text;
+      });
+  } else {
+    // remove padched
+    document.querySelectorAll('.padChedDiv')
+      .forEach(element => element.parentNode.removeChild(element));
+  }
+}
+
 function shabadToggle(e) {
   e.currentTarget.classList.toggle('active');
-  const option = e.currentTarget.id;
+  const el = e.currentTarget;
+  const option = el.id;
+  let toggle = {};
+
   switch (option) {
     case 'display-options-toggle':
-      document.querySelector('#display-options').classList.toggle('hidden');
+      toggleHiddenFlex(document.getElementById('display-options'));
       break;
-    case 'unicode-toggle':
+    case 'font-options-toggle':
+      toggleHiddenFlex(document.getElementById('font-options'));
+      break;
     case 'larivaar-toggle':
-    case 'larivaar_assist-toggle': {
-      const [toggle] = e.target.id.split('-');
+      [toggle] = option.split('-');
+      document.querySelector('.display').classList.toggle(toggle);
+      checkboxPref(e, 'shabadToggles', option);
+      addSpaceForPadChed((prefs.shabadToggles.indexOf('larivaar-toggle') < 0));
+      break;
+    case 'larivaar_assist-toggle':
+    case 'unicode-toggle':
+      [toggle] = option.split('-');
       document.querySelector('.display').classList.toggle(toggle);
       checkboxPref(e, 'shabadToggles', option);
       break;
-    }
+    default:
+      break;
   }
+}
+
+function toggleHiddenFlex(e) {
+  e.style.display = (e.style.display === 'none' || e.style.display === '')? 'flex' : 'none';
 }
 
 function displayOptionToggle(e) {
@@ -190,3 +267,23 @@ function displayOptionToggle(e) {
           .join('\n')
       )));
 }
+
+getPrefs();
+
+if ($searchType) $searchType.addEventListener('change', updateSearchLang);
+
+if ($searchType) $searchType.addEventListener('change', updateSearchAction);
+
+$search.onkeyup = function () {
+  const value = this.value;
+  const clearSearchToggle = document.querySelector('.clear-search-toggle');
+  if (value.length > 0) {
+    clearSearchToggle.classList.add('active');
+  } else {
+    clearSearchToggle.classList.remove('active');
+  }
+  // Remove non-numeric characters for Ang search
+  if (parseInt($searchType.value, 10) === 5) {
+    forceSearchNumeric();
+  }
+};

--- a/src/js/renderControls.js
+++ b/src/js/renderControls.js
@@ -85,14 +85,23 @@ function renderControls() {
       </div>
       <div id="shabad-controllers">
         <a id="display-options-toggle" class="shabad-controller-toggle" click={shabadToggle}>
-          <i class="fa fa-sliders" />
-          <span>Display Options ↓</span>
+          <i class="fa fa-television" />
+          <span>Display</span>
         </a>
-        <a id="unicode-toggle" class="shabad-controller-toggle" click={shabadToggle}>Unicode</a>
-        <a id="larivaar-toggle" class="shabad-controller-toggle" click={shabadToggle}>Larivaar</a>
-        <a id="larivaar_assist-toggle" class="shabad-controller-toggle" click={shabadToggle}>Larivaar Assist</a>
+        <a id="font-options-toggle" class="shabad-controller-toggle" click={shabadToggle}>
+          <i class="fa fa-sliders" />
+          <span>Font</span>
+        </a>
+        <a id="larivaar-toggle" class="shabad-controller-toggle" click={shabadToggle}>
+          <span class="custom-fa">ੳਅ</span>
+          <span>Larivaar</span>
+        </a>
+        <a id="larivaar_assist-toggle" class="shabad-controller-toggle" click={shabadToggle}>
+          <span class="custom-fa custom-fa-assist">ੳ</span>
+          <span>Assist</span>
+        </a>
       </div>
-      <div id="display-options" class="hidden">
+      <div id="display-options">
         <div class="display-option-type">
           <div class="display-option-header">Transliteration</div>
           <a id="transliteration-english" class="display-option-toggle" click={displayOptionToggle}>English</a>
@@ -106,6 +115,16 @@ function renderControls() {
         <div class="display-option-type">
           <div class="display-option-header">Split View</div>
           <a id="split-view" class="display-option-toggle" click={displayOptionToggle}>Split View</a>
+        </div>
+      </div>
+      <div id="font-options">
+        <div class="font-option-type">
+          <div class="font-option-header">Font</div>
+            <a id="unicode-toggle" class="shabad-controller-toggle" click={shabadToggle}>Unicode</a>
+        </div>
+        <div class="font-option-type">
+          <div class="font-option-header">Font Size</div>
+          <small class="gurbani-font">A</small><input type="range" min="5" max="50" value="16" id="font-size-slider" onchange="displayOptionSlider(this)" oninput="displayOptionSlider(this)" /><big class="gurbani-font">A</big>
         </div>
       </div>
     </div>

--- a/src/js/renderGurmukhiKeyboard.js
+++ b/src/js/renderGurmukhiKeyboard.js
@@ -16,13 +16,10 @@ function renderGurmukhiKeyboard($search) {
         $search.value = $search.value.substring(0, $search.value.length - 1);
         break;
       }
-      case 'close': {
-        $keyboard.classList.remove('active');
-        break;
-      }
       case 'page-1': case 'page-2': {
-        $($keyboard.querySelector('.page')).hide();
-        $("#gurmukhi-keyboard-" + action).show();
+        [...$keyboard.querySelectorAll('.page')]
+          .forEach((e) => { e.style.display = 'none'; });
+        document.getElementById(`gurmukhi-keyboard-${action}`).style.display = 'block';
         break;
       }
       default: {
@@ -93,17 +90,15 @@ function renderGurmukhiKeyboard($search) {
           <div class="keyboard-row-set">
             <button type="button">&nbsp;</button>
             <button type="button">&nbsp;</button>
-            <button type="button" data-action="close">
-              <i class="fa fa-times" />
-            </button>
-            <button type="button" data-action="page-2">uI</button>
+            <button type="button" data-action="page-1" class="active">1</button>
+            <button type="button" data-action="page-2">2</button>
             <button type="button" data-action="bksp">
               <i class="fa fa-long-arrow-left" />
             </button>
           </div>
         </div>
       </div>
-      <div class="page" d="gurmukhi-keyboard-page-2">
+      <div class="page" id="gurmukhi-keyboard-page-2">
         <div class="keyboard-row">
           <div class="keyboard-row-set">
             <button type="button">1</button>
@@ -163,10 +158,8 @@ function renderGurmukhiKeyboard($search) {
           <div class="keyboard-row-set">
             <button type="button">&nbsp;</button>
             <button type="button">&nbsp;</button>
-            <button type="button" data-action="close">
-              <i class="fa fa-times" />
-            </button>
-            <button type="button" data-action="page-1">a</button>
+            <button type="button" data-action="page-1">1</button>
+            <button type="button" data-action="page-2" class="active">2</button>
             <button type="button" data-action="bksp">
               <i class="fa fa-long-arrow-left" />
             </button>

--- a/src/js/renderShabad.js
+++ b/src/js/renderShabad.js
@@ -22,6 +22,16 @@ function renderShabad(gurbani, nav) {
     .concat(prefs.shabadToggles)
     .forEach(option => document.getElementById(option).click());
 
+    addSpaceForPadChed((prefs.shabadToggles.indexOf('larivaar-toggle') < 0));
+
+    Object
+    .keys(prefs.sliders)
+    .forEach((key) => {
+      const s = document.getElementById(key);
+      s.value = prefs.sliders[key];
+      displayOptionSlider(s);
+    });
+
   $controls.classList.remove('hidden');
 }
 
@@ -50,21 +60,23 @@ function metaData(data, nav) {
   gurmukhi_meta.push(data.source.gurmukhi);
   english_meta.push(data.source.english);
 
-  gurmukhi_meta.push(
-    (
-      <a href={`/ang?ang=${data.source.pageno}&source=${data.source.id}`}>
-        {`${page_type_gurmukhi} ${data.source.pageno}`}
-      </a>
-    ).outerHTML
-  );
+  if (data.source.pageno !== null) {
+    gurmukhi_meta.push(
+      (
+        <a href={`/ang?ang=${data.source.pageno}&source=${data.source.id}`}>
+          {`${page_type_gurmukhi} ${data.source.pageno}`}
+        </a>
+      ).outerHTML
+    );
 
-  english_meta.push(
-    (
-      <a href={`/ang?ang=${data.source.pageno}&source=${data.source.id}`}>
-        {`${page_type_english} ${data.source.pageno}`}
-      </a>
-    ).outerHTML
-  );
+    english_meta.push(
+      (
+        <a href={`/ang?ang=${data.source.pageno}&source=${data.source.id}`}>
+          {`${page_type_english} ${data.source.pageno}`}
+        </a>
+      ).outerHTML
+    );
+  }
 
   if (typeof nav !== 'undefined') {
     const link = navLink(nav, data.source.id);
@@ -192,7 +204,7 @@ function prepareLarivaar(padChhed) {
     .split(' ')
     .map(val => (val.indexOf('॥') !== -1 || val.indexOf(']') !== -1)
       ? `<i>${val} </i>`
-      : `<div class="akhar">${val}</div>`
+      : `<span class="akhar">${val }</span>`
     )
     .join('')
 }

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -49,7 +49,7 @@ const routes = {
     $$searchContainer.appendChild(gurmukhiKeyboard);
 
     const mockEvent = {
-      currentTarget: {
+      target: {
         value: $$searchType.value || 0,
         form: document.querySelector('.search-form'),
       }
@@ -149,7 +149,7 @@ function router () {
       routes[currentRoute]($contentRoot, $lastScriptTag);
       break;
     }
-    case '/about': case '/terms-of-service': {
+    case '/about': case '/help': case '/terms-of-service': {
       routes.default($contentRoot, $lastScriptTag, content[pathname]);
       break;
     }

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -21,7 +21,7 @@ $(function() {
   loadResults();
 });
 
-function loadResults(offset) {
+function loadResults(offset = null) {
   $.ajax({
     url: Khajana.buildApiUrl({ q, type, source, offset }),
     dataType: "json",
@@ -57,22 +57,36 @@ function loadResults(offset) {
         }
       }
 
-      [...prefs.displayOptions, ...prefs.shabadToggles]
-        .forEach(option => document.getElementById(option).click())
+      if (!offset) {
+        [...prefs.displayOptions, ...prefs.shabadToggles]
+          .forEach(option => document.getElementById(option).click());
 
-      $controls.classList.remove('hidden');
+        addSpaceForPadChed((prefs.shabadToggles.indexOf('larivaar-toggle') < 0));
+        $controls.classList.remove('hidden');
+      }
+
+      Object
+        .keys(prefs.sliders)
+        .forEach((key) => {
+          const s = document.getElementById(key);
+          s.value = prefs.sliders[key];
+          displayOptionSlider(s);
+        });
+
     },
     error: showError
   });
 }
 
-function getShabadHyperLink (shabad) {
+function getShabadHyperLink(shabad) {
   return `/shabad?id=${shabad.shabadid}&q=${q}${type ? `&type=${type}` : ''}${source ? `&source=${source}` : ''}`;
 }
 
 function addSearchResult(shabad, q) {
   const _source = Khajana.SOURCES[shabad.source.id];
-  const source = _source ? `${_source} - ${shabad.pageno}`: null;
+  //if page num is null
+  const shabadPageNo = (shabad.pageno === null) ? '' : shabad.pageno;
+  const source = _source ? `${_source} - ${shabadPageNo}` : null;
 
   $searchResults.appendChild(
     h('li', { class: 'search-result' }, [
@@ -92,9 +106,9 @@ function addSearchResult(shabad, q) {
     h('blockquote', { class: 'translation english' }, shabad.translation.english.ssk),
     h('blockquote', { class: 'translation spanish' }, shabad.translation.spanish),
       h('div', { class: 'meta flex wrap'} , [
-        source && h('a', { href: '#', }, source),
-        h('a', { href: '#', }, `${shabad.writer.english}`),
-        ['No Raag', null].every(s => s !== shabad.raag.english) && h('a', { href: '#', }, `${shabad.raag.english}`),
+        source && h('a', { href: '#' }, source),
+        h('a', { href: '#' }, `${shabad.writer.english}`),
+        (shabad.raag.english === 'No Raag' || shabad.raag.english === null) ? '' : h('a', { href: '#' }, shabad.raag.english),
       ])
     ])
   );

--- a/src/js/shabad.js
+++ b/src/js/shabad.js
@@ -8,6 +8,9 @@ $(function() {
     url: Khajana.buildApiUrl(typeof random !== 'undefined' ? { random: true } : { id }),
     dataType: "json",
     success: function(data) {
+      if (typeof random !== 'undefined') {
+        window.history.replaceState('', '', `/shabad?id=${data.shabadinfo.id}`);
+      }
       $shabad.innerHTML = '';
       data.navigation.type = 'shabad';
       metaData(data.shabadinfo, data.navigation);

--- a/src/scss/_colours.scss
+++ b/src/scss/_colours.scss
@@ -1,0 +1,2 @@
+$sttm-blue: #01669b;
+$sttm-orange: #f39c1d;

--- a/src/scss/_display-controls.scss
+++ b/src/scss/_display-controls.scss
@@ -13,6 +13,33 @@
   }
 }
 
+#display-options,
+#font-options {
+  align-content: flex-start;
+  background-color: #fafafa;
+  display: none;
+  flex-wrap: wrap;
+  margin: 0 auto;
+  width: calc(100% - 2rem);
+}
+
+@media screen and (min-width: 46em) {
+  #display-options,
+  #font-options {
+    width: calc(100% - 5rem);
+  }
+}
+
+#display-options-toggle span,
+#font-options-toggle span {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='32' height='24' viewBox='0 0 32 24'><polygon points='0,0 32,0 16,24' style='fill: rgb%28138, 138, 138%29'></polygon></svg>");
+  background-origin: content-box;
+  background-position: right -1rem center;
+  background-repeat: no-repeat;
+  background-size: 9px 6px;
+  padding-right: 1rem;
+}
+
 @media screen and (min-width: 46em) {
   #controls-wrapper {
     top: 0;
@@ -24,12 +51,28 @@
 }
 
 #shabad-controllers {
+  /* Opera doesn't support this in the shorthand */
+  background-attachment: local, local, scroll, scroll;
+
+  /* do not change order of below */
+  background-image:
+    /* Shadows */
+    linear-gradient(to right, #f5f5f5, #f5f5f5),
+    linear-gradient(to right, #f5f5f5, #f5f5f5),
+    /* Shadow covers */
+    linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(245, 245, 245, 0)),
+    linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(245, 245, 245, 0));
+  background-position: left center, right center, left center, right center;
+  background-repeat: no-repeat;
+  background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+  margin: 0.25rem auto;
   overflow-x: auto;
   white-space: nowrap;
 }
 
 .shabad-controller-toggle,
-.display-option-toggle {
+.display-option-toggle,
+.font-option-toggle {
   border: 1px solid #cacaca;
   border-radius: 2px;
   color: #3c3c3c;
@@ -53,8 +96,16 @@
     color: white;
   }
 
-  i {
+  i,
+  .custom-fa {
     margin-right: 4px;
+  }
+
+  .custom-fa-assist {
+    &::after {
+      color: $sttm-orange;
+      content: 'ਅ';
+    }
   }
 }
 
@@ -63,6 +114,12 @@
   display: none;
 }
 
-.display-option-type {
-  margin-bottom: 1rem;
+.display-option-type,
+.font-option-type {
+  margin: 1rem auto 1rem 0;
+
+  big,
+  small {
+    margin: 5px;
+  }
 }

--- a/src/scss/_footer.scss
+++ b/src/scss/_footer.scss
@@ -2,10 +2,17 @@ footer {
   background-color: #fafafa;
   border-top: 1px solid #ebebeb;
   bottom: 0;
-  height: 49px;
   left: 0;
+  min-height: 49px;
   position: absolute;
   width: 100%;
+
+  .menu {
+    align-content: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+  }
 
   .menu li a {
     color: #3c3c3c;

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -84,9 +84,19 @@
     background-color: #01669b;
   }
 
-  .gurmukhi-keyboard-toggle {
+  .gurmukhi-keyboard-toggle,
+  .clear-search-toggle {
     background-color: #fff;
     color: #999;
+    width: 44px;
+
+    &.active {
+      color: $sttm-orange;
+    }
+  }
+
+  .clear-search-toggle {
+    width: 22px;
   }
 }
 
@@ -101,7 +111,7 @@
   height: 44px;
   margin: 0;
   position: relative;
-  width: calc(100% - 88px);
+  width: calc(100% - 110px);
 }
 
 .gurmukhi-keyboard {
@@ -141,15 +151,40 @@
 
   .keyboard-row:nth-child(2n-1) .keyboard-row-set:nth-child(1),
   .keyboard-row:nth-child(2n) .keyboard-row-set:nth-child(2) {
-    background-color: #ccc;
+    background-color: #ececec;
   }
 
   button {
     color: #333;
     font-size: 1rem;
     line-height: 2;
+    position: relative;
     text-align: center;
     width: 20%;
+
+    &.active {
+      color: $sttm-orange;
+    }
+
+    &[data-action="page-1"] {
+      padding-right: 5px;
+      text-align: right;
+
+      &::after {
+        color: #000;
+        content: "|";
+        font-family: Helvetica Neue, Helvetica, Roboto, Arial, sans-serif;
+        font-size: 0.8rem;
+        position: absolute;
+        right: -1px;
+        top: 2px;
+      }
+    }
+
+    &[data-action="page-2"] {
+      padding-left: 4px;
+      text-align: left;
+    }
   }
 }
 
@@ -285,7 +320,7 @@
 
   .top-bar #search {
     max-width: 400px;
-    width: 356px;
+    width: 334px;
   }
 
   #search-options {

--- a/src/scss/_helpers.scss
+++ b/src/scss/_helpers.scss
@@ -85,3 +85,4 @@
 .flex.space-between {
   justify-content: space-between;
 }
+

--- a/src/scss/_panktee.scss
+++ b/src/scss/_panktee.scss
@@ -20,10 +20,9 @@
 
   .akhar {
     display: inline-block;
-    transition: all .25s;
-    padding-right: 0.5rem;
+    transition: all 0.25s;
   }
-  
+
   .split-view-baani {
     display: none;
   }
@@ -56,7 +55,7 @@
   &.transliteration-english .transliteration.english {
     display: block;
   }
-  
+
   &.larivaar .akhar {
     padding-right: 0;
   }
@@ -67,4 +66,9 @@
       color: #f39c1d;
     }
   }
+}
+
+.padChedDiv {
+  display: inline-block;
+  white-space: pre;
 }

--- a/src/scss/_shabad-page.scss
+++ b/src/scss/_shabad-page.scss
@@ -18,6 +18,10 @@ blockquote {
   padding: 1rem;
   text-align: center;
   width: calc(100% - 2rem);
+
+  &:empty {
+    display: none;
+  }
 }
 
 .shabad-nav {

--- a/src/scss/_sharing.scss
+++ b/src/scss/_sharing.scss
@@ -5,6 +5,7 @@
   border-radius: 2px;
   float: right;
   height: calc(10px + 2em);
+  margin-bottom: 0.5rem;
   margin-right: 35px;
   padding: 0 35px !important;
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,4 +1,5 @@
 @import
+  "colours",
   "display-controls",
   "error-page",
   "footer",


### PR DESCRIPTION
You can see the borders when Shabad is being fetched. This simply hides it whenever the contents of `#metadata` are empty.