### PR TITLE
Hide meta data borders when empty

### DIFF
--- a/src/scss/_shabad-page.scss
+++ b/src/scss/_shabad-page.scss
@@ -18,6 +18,10 @@ blockquote {
   padding: 1rem;
   text-align: center;
   width: calc(100% - 2rem);
+
+  &:empty {
+    display: none;
+  }
 }
 
 .shabad-nav {


### PR DESCRIPTION
<!-- Please provide one line description of the changes you made.
Example: I updated the logic for this function to cover more cases. -->

Hides borders of meta data area when it's empty. You can notice these borders during loading states.
<!-- Before submitting a PR, we would like you to confirm the following: -->

* [x] <!-- I --> Ran `npm test`.
* [x] <!-- I --> Checked console for errors.
* [x] <!-- I --> Searched a shabad successfully.

<!-- New to markdown? Put a 'x' between [ ] to confirm. Example: -->
<!-- * [x] Ran `npm test`. -->
<!-- * [x] Checked console for errors. -->
<!-- * [ ] Searched a shabad successfully. -->
